### PR TITLE
linking concerts on the homepage to their details

### DIFF
--- a/app/front/presenters/templates/Homepage/default.latte
+++ b/app/front/presenters/templates/Homepage/default.latte
@@ -51,7 +51,10 @@
 							<ul class="list-group">
 								<li class="list-group-item" n:foreach="$concerts as $id => $concert">
 									<!-- <span class="badge pull-right">{$concert->date|timeLeft}</span> -->
-									<h5>{$concert->name}</h5>
+									<a 	href="{link :Front:Concert:detail $concert -> id}" 
+										title="{$concert->name}">
+										<h5>{$concert->name}</h5>
+									</a>
 									<small>{$concert->date|weekday}, {$concert->date|date: 'd. m. H:i'}</small>
 								</li>
 							</ul>


### PR DESCRIPTION
fixes #29 
![koncerty_odkazy](https://cloud.githubusercontent.com/assets/9808924/20229501/10e4d142-a857-11e6-945c-89b3d574f9ab.PNG)
